### PR TITLE
Add markdown about section and professional copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.20.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/public/about.md
+++ b/public/about.md
@@ -1,0 +1,33 @@
+# ¡Hola! Soy Manuel García Cobos
+
+Desarrollador web orientado a producto. Construyo interfaces limpias y **funcionales** y disfruto integrando APIs y mejorando la experiencia de usuario.
+
+## Lo que hago
+- Frontend con **React / Next.js**
+- Integración de APIs (REST, OpenAI)
+- UI accesible y responsive
+- Deploy (Vercel / GitHub Pages)
+
+## Tecnologías
+**React, Next.js, JavaScript, HTML, CSS, Node.js, Express, MongoDB, MySQL, Git**
+
+## Proyectos destacados
+- **Comer-IA** — Generador de recetas con IA (Next.js + OpenAI).  
+  _Rol:_ desarrollo end-to-end, UI responsive, despliegue.  
+  **Demo:** https://www.comer-ia.com/
+
+- **Wahaha** — Mini red social de chistes (full-stack).  
+  _Rol:_ diseño UX/UI, funcionalidades, mejoras continuas.
+
+- **SimonaZappoli** — Web estática para negocio real.  
+  **Demo:** https://simona-zappoli.pages.dev/
+
+- **Adivina el Número** — Juego web simple con niveles.  
+  **Demo:** https://gessthenumber.pages.dev/
+
+- **Rick and Morty** — Listado con scroll infinito + búsqueda.  
+  **Demo:** https://rick-and-morty-characters.pages.dev/
+
+## Contacto
+- **Email:** wahandricode@gmail.com  
+- **LinkedIn:** https://www.linkedin.com/in/manuel-garc%C3%ADa-cobos-6b5413272/

--- a/src/App.js
+++ b/src/App.js
@@ -1,26 +1,31 @@
 import "./App.css";
 import React from "react";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import Footer from "./components/Footer/Footer";
+import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import Header from "./components/Header/Header";
+import Footer from "./components/Footer/Footer";
 import Start from "./components/Start/Start";
-import NumberGames from "./components/NumberGames/NumberGames";
+import About from "./components/About/About";
+import Projects from "./components/Projects/Projects";
 
-function App() {
+export default function App() {
   return (
     <Router>
-      <div className="App">
-        <Header />
-        <div className="paddingApp">
-          <Routes>
-            <Route path="/" element={<Start />} />
-            <Route path="/findTheNumber" element={<NumberGames />} />
-          </Routes>
-        </div>
-        <Footer />
-      </div>
+      <Header />
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <>
+              <Start />
+              <About />
+              <Projects />
+            </>
+          }
+        />
+        <Route path="/about" element={<About />} />
+        <Route path="/projects" element={<Projects />} />
+      </Routes>
+      <Footer />
     </Router>
   );
 }
-
-export default App;

--- a/src/BodyJs.js
+++ b/src/BodyJs.js
@@ -1,0 +1,2 @@
+console.log("🧠 Aportando valor desde el primer día como programador.");
+console.log("🚀 Mejora continua y foco en entregar resultados.");

--- a/src/components/About/About.css
+++ b/src/components/About/About.css
@@ -1,0 +1,12 @@
+.container { max-width: 980px; margin: 0 auto; padding: 24px; }
+.about-card {
+  background: #111418;
+  border: 1px solid #232a33;
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 6px 20px rgba(0,0,0,.25);
+}
+.about-card h1, .about-card h2, .about-card h3 { margin: 0.6em 0 0.4em; }
+.about-card p, .about-card li { line-height: 1.7; }
+.about-card a { text-decoration: none; border-bottom: 1px dotted currentColor; }
+.about-card a:hover { opacity: .85; }

--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import "./About.css";
+
+export default function About() {
+  const [markdown, setMarkdown] = useState("");
+
+  useEffect(() => {
+    fetch(process.env.PUBLIC_URL + "/about.md")
+      .then((res) => res.text())
+      .then(setMarkdown)
+      .catch(() => setMarkdown("# Sobre mí\nNo se pudo cargar el contenido."));
+  }, []);
+
+  return (
+    <section className="about container">
+      <div className="about-card">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Greeting/Greeting.js
+++ b/src/components/Greeting/Greeting.js
@@ -1,87 +1,14 @@
-import React, { useState, useEffect } from "react";
-import hombre from "../../images/hombre.png";
-import fondoTek from "../../images/fondoTek.png";
+import React from "react";
 import "./Greeting.css";
 
 export default function Greeting() {
-  const [greeting, setGreeting] = useState(
-    'Hola, mi nombre es <span class="color2">Manuel</span>'
-  );
-  const [showMore, setShowMore] = useState(false);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setGreeting((prevGreeting) =>
-        prevGreeting === 'Hola, mi nombre es <span class="color2">Manuel</span>'
-          ? 'Pero me dicen <span class="color2">Wahandri</span>'
-          : 'Hola, mi nombre es <span class="color2">Manuel</span>'
-      );
-    }, 3000);
-    return () => clearInterval(interval);
-  }, []);
-
   return (
-    <div className="boxGreeting flexCenter">
-      <div className="boxMyDescription hello">
-        <div className="helloImg">
-          <div className="textStart">
-            <h1
-              className="fixed"
-              dangerouslySetInnerHTML={{ __html: greeting }}
-            />
-            <h1>
-              Y soy <span className="color2">Desarrollador Web Fullstack</span>
-            </h1>
-          </div>
-          <div className="divMen">
-            <img className="imgMen shadowMen" src={hombre} alt="" />
-            <img className=" imgMen backgroundTek" src={fondoTek} alt="" />
-          </div>
-        </div>
-        <div className="myDescription">
-          <h3>
-            ¡Hola! Soy Manuel García, tengo 30 años y soy{" "}
-            <span className="color2">Desarrollador Web Full-Stack</span> con una
-            sólida formación en{" "}
-            <a
-              href="https://codespaceacademy.com/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Codespace Academy
-            </a>
-            . Mi curiosidad insaciable por la creación y la resolución de
-            problemas me impulsa a seguir aprendiendo y aplicando mis
-            conocimientos en proyectos personales.
-          </h3>
-          {showMore && ( // Si showMore es true, se muestra el segundo <h3>
-            <h3>
-              Mi naturaleza optimista y mi enfoque orientado hacia la
-              consecución de metas, junto con mi habilidad para colaborar
-              efectivamente en equipo, son aspectos clave de mi personalidad.
-              <br /> A pesar de tener una experiencia laboral aún incipiente,
-              considero que mi intensa formación durante un año en la academia y
-              la dedicación constante a proyectos personales han sido
-              fundamentales en mi evolución profesional.
-              <br />
-              <br /> Este periodo incluye el desarrollo de un sitio web sin
-              costo para un pequeño negocio real, una experiencia que ha
-              enriquecido significativamente mi aprendizaje. Me siento
-              plenamente capacitado para elevar mis habilidades a un nivel
-              superior, enfrentando con éxito los retos que presenta el mundo
-              laboral del desarrollo web.
-              <br />
-              <br /> Estoy entusiasmado con la idea de continuar mi crecimiento
-              profesional y aportar de manera notable a los proyectos futuros.
-            </h3>
-          )}
-          <button className="btnRead" onClick={() => setShowMore(!showMore)}>
-            {" "}
-            {/* Botón para mostrar/ocultar el segundo <h3> */}
-            {showMore ? "Read less" : "Read more"}
-          </button>
-        </div>
+    <>
+      {/* Hero */}
+      <div className="hero">
+        <h1>Hola, soy Manuel — Desarrollador Web</h1>
+        <p>Programo interfaces claras, integro APIs y cuido el detalle.</p>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/Start/Start.js
+++ b/src/components/Start/Start.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import "./Start.css"
-import Greeting from "../Greeting/Greeting"
+import Greeting from "../Greeting/Greeting";
 import Skills from '../Skills/Skills';
-import Projects from '../Projects/Projects';
 
 
 export default function Start() {
@@ -10,7 +9,6 @@ export default function Start() {
     <div>
         <Greeting />
         <Skills />
-        <Projects />
     </div>
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import './BodyJs';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- add markdown support via react-markdown and remark-gfm
- render new markdown-based about section
- refresh hero and console orientation copy
- wire about section into main routes

## Testing
- `npm i` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-markdown)*
- `npm run build` *(fails: Module not found: Can't resolve 'remark-gfm')*
- `npm start` *(fails: Module not found: Can't resolve 'react-markdown')*

------
https://chatgpt.com/codex/tasks/task_e_68b8a6c309308323b0980a55c503e9f7