### PR TITLE
Refactor VSCode simulator to use centralized data

### DIFF
--- a/src/components/BodyEnv/BodyEnv.js
+++ b/src/components/BodyEnv/BodyEnv.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import datos from '../../data/datos.json';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+export default function BodyEnv() {
+  const { contacto, ubicacion } = datos;
+
+  const env = `# contacto.env
+EMAIL=${contacto.email}
+LINKEDIN=${contacto.linkedin}
+LOCATION="${ubicacion}"`;
+
+  return (
+    <div className='boxSizeText'>
+      <p className='headerVSC'>Home &gt; Document &gt; Portfolio &gt; contacto.env</p>
+      <SyntaxHighlighter language="bash" style={vscDarkPlus} showLineNumbers startingLineNumber={1}>
+        {env}
+      </SyntaxHighlighter>
+    </div>
+  );
+}

--- a/src/components/BodyJson/BodyJson.js
+++ b/src/components/BodyJson/BodyJson.js
@@ -1,77 +1,14 @@
 import React from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
-
-const code = `{
-  "nombre": "Manuel García Cobos",
-  "titulo": "Desarrollador Web Junior",
-  "ubicacion": "Málaga, España",
-  "contacto": {
-    "email": "wahandricode@gmail.com",
-    "linkedin": "https://www.linkedin.com/in/manuel-garc%C3%ADa-cobos-6b5413272/"
-  },
-  "habilidades": [
-    "HTML", "CSS", "JavaScript", "Git", "React",
-    "Node.js", "Next.js", "Express", "MongoDB", "MySql"
-  ],
-  "intereses": [
-    "Desarrollo de software",
-    "Inteligencia Artificial",
-    "Documentales",
-    "Baloncesto",
-    "Senderismo"
-  ],
-  "formacion": [
-    {
-      "centro": "Code Space Academy",
-      "titulo": "Desarrollo Web Full Stack",
-      "fecha": "Octubre 2022 - Octubre 2023"
-    },
-    {
-      "centro": "IES La Rosaleda, Málaga",
-      "titulo": "Educación Secundaria Obligatoria (E.S.O.)",
-      "fecha": "Junio 2010"
-    }
-  ],
-  "experiencia": [
-    {
-      "proyecto": "Comer-IA",
-      "descripcion": "App con Next.js que genera recetas usando la API de OpenAI. Trabajé en integración de IA, despliegue y diseño responsive.",
-      "tecnologias": ["Next.js", "OpenAI API", "CSS"],
-      "link": "https://www.comer-ia.com/"
-    },
-    {
-      "proyecto": "Wahaha",
-      "descripcion": "Red social de chistes donde los usuarios pueden subir, puntuar y guardar favoritos. Proyecto full stack con énfasis en UX y diseño.",
-      "tecnologias": ["React", "Node.js", "MongoDB", "JavaScript", "CSS"],
-      "link": null
-    },
-    {
-      "proyecto": "SimonaZappoli",
-      "descripcion": "Sitio web estático para una profesional del bienestar. Diseñado según necesidades reales del cliente, con enfoque en usabilidad.",
-      "tecnologias": ["React", "HTML", "CSS", "JavaScript"],
-      "link": "https://simona-zappoli.pages.dev/"
-    },
-    {
-      "proyecto": "Adivina el Número",
-      "descripcion": "Juego web simple para practicar lógica y control de flujo en JavaScript. Incluye niveles de dificultad.",
-      "tecnologias": ["HTML", "CSS", "JavaScript"],
-      "link": "https://gessthenumber.pages.dev/"
-    },
-    {
-      "proyecto": "Rick and Morty API",
-      "descripcion": "App que consume la API de Rick and Morty con scroll infinito y búsqueda en tiempo real. Enfocada en el diseño y consumo de API.",
-      "tecnologias": ["React", "JavaScript", "CSS", "Rick and Morty API"],
-      "link": "https://rick-and-morty-characters.pages.dev/"
-    }
-  ]
-}
-`;
+import datos from '../../data/datos.json';
 
 export default function BodyJson() {
+  const code = JSON.stringify(datos, null, 2);
+
   return (
     <div className='boxSizeText'>
-      <p className='headerVSC'>Home > Document > Portfolio > SobreMi.json</p>
+      <p className='headerVSC'>Home &gt; Document &gt; Portfolio &gt; datos.json</p>
       <SyntaxHighlighter language="json" style={vscDarkPlus} showLineNumbers startingLineNumber={1}>
         {code}
       </SyntaxHighlighter>

--- a/src/components/BodyMd/BodyMd.js
+++ b/src/components/BodyMd/BodyMd.js
@@ -1,30 +1,39 @@
 import React from 'react';
+import datos from '../../data/datos.json';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'; // Ejemplo de estilo compatible
-
-const code = `# Experiencia
-
-**Educación:**
-- Institución: Nombre de tu institución educativa
-- Título: Título obtenido (p. ej., Ingeniería Informática)
-- Año de graduación: Año de graduación
-
-**Proyectos:**
-1. **Nombre del proyecto**:
-   - Descripción: Breve descripción del proyecto y tu rol en él
-   - Tecnologías: Lista de tecnologías utilizadas
-
-2. **Otro proyecto**:
-   - Descripción: Breve descripción del proyecto y tu rol en él
-   - Tecnologías: Lista de tecnologías utilizadas`;
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 export default function BodyMd() {
+  const { nombre, titulo, ubicacion, intereses, habilidades, experiencia, contacto } = datos;
+
+  const destacados = experiencia.slice(0, 2).map(p => `- **${p.proyecto}** — ${p.descripcion}`).join('\n');
+
+  const md = `# ${nombre}
+
+${titulo} — ${ubicacion}
+
+Desarrollador orientado a producto. Construyo interfaces **limpias y funcionales**, integro APIs y cuido la experiencia de usuario.
+
+## Tecnologías
+${habilidades.join(' · ')}
+
+## Intereses
+${intereses.join(' · ')}
+
+## Proyectos destacados
+${destacados}
+
+## Contacto
+- **Email:** ${contacto.email}
+- **LinkedIn:** ${contacto.linkedin}
+`;
+
   return (
-    <>
-    <p className='headerVSC'>Home > Document > Portfolio > Experiencia.md</p>
-    <SyntaxHighlighter language="markdown" style={vscDarkPlus}>
-      {code}
-    </SyntaxHighlighter>
-    </>
+    <div className='boxSizeText'>
+      <p className='headerVSC'>Home &gt; Document &gt; Portfolio &gt; SobreMi.md</p>
+      <SyntaxHighlighter language="markdown" style={vscDarkPlus} showLineNumbers startingLineNumber={1}>
+        {md}
+      </SyntaxHighlighter>
+    </div>
   );
 }

--- a/src/components/VSC/VSC.js
+++ b/src/components/VSC/VSC.js
@@ -2,22 +2,22 @@ import React, { useState } from 'react';
 import "./VSC.css";
 import iconJs from "../../images/jsIcon.png";
 import iconJson from "../../images/jsonIcon.png";
-// import iconMd from "../../images/mdIcon.png";
-import BodyJson from '../BodyJson/BodyJson';
+import iconMd from "../../images/mdIcon.png";
 import BodyMd from '../BodyMd/BodyMd';
-import BodyJs from '../BodyJs/BodyJs';
+import BodyEnv from '../BodyEnv/BodyEnv';
+import BodyJson from '../BodyJson/BodyJson';
 
 export default function VSC() {
-  const [activeTab, setActiveTab] = useState('SobreMi.json');
+  const [activeTab, setActiveTab] = useState('SobreMi.md');
 
   const renderContent = () => {
     switch (activeTab) {
-      case 'SobreMi.json':
-        return <BodyJson />;
-      case 'Experiencia.md':
+      case 'SobreMi.md':
         return <BodyMd />;
-      case 'Objetivo.js':
-        return <BodyJs />;
+      case 'contacto.env':
+        return <BodyEnv />;
+      case 'datos.json':
+        return <BodyJson />;
       default:
         return null;
     }
@@ -30,13 +30,17 @@ export default function VSC() {
   return (
     <div className='boxVSC borderCard'>
       <header className='boxHeaderVSC'>
-        <div className={getTabClassName('SobreMi.json')} onClick={() => setActiveTab('SobreMi.json')}>
-          <img width="30px" alt='' src={iconJson} /> 
-          <p>SobreMi.json</p>
+        <div className={getTabClassName('SobreMi.md')} onClick={() => setActiveTab('SobreMi.md')}>
+          <img width="30px" alt='' src={iconMd} />
+          <p>SobreMi.md</p>
         </div>
-        <div className={getTabClassName('Objetivo.js')} onClick={() => setActiveTab('Objetivo.js')}>
-          <img width="20px" alt='' src={iconJs} /> 
-          <p>Objetivo.js</p>
+        <div className={getTabClassName('contacto.env')} onClick={() => setActiveTab('contacto.env')}>
+          <img width="20px" alt='' src={iconJs} />
+          <p>contacto.env</p>
+        </div>
+        <div className={getTabClassName('datos.json')} onClick={() => setActiveTab('datos.json')}>
+          <img width="30px" alt='' src={iconJson} />
+          <p>datos.json</p>
         </div>
       </header>
       <div className='boxBodyVSC'>

--- a/src/data/datos.json
+++ b/src/data/datos.json
@@ -1,0 +1,64 @@
+{
+  "nombre": "Manuel García Cobos",
+  "titulo": "Desarrollador Web Junior",
+  "ubicacion": "Málaga, España",
+  "contacto": {
+    "email": "wahandricode@gmail.com",
+    "linkedin": "https://www.linkedin.com/in/manuel-garc%C3%ADa-cobos-6b5413272/"
+  },
+  "habilidades": [
+    "HTML", "CSS", "JavaScript", "Git", "React",
+    "Node.js", "Next.js", "Express", "MongoDB", "MySQL"
+  ],
+  "intereses": [
+    "Desarrollo de software",
+    "Inteligencia Artificial",
+    "Documentales",
+    "Baloncesto",
+    "Senderismo"
+  ],
+  "formacion": [
+    {
+      "centro": "Code Space Academy",
+      "titulo": "Desarrollo Web Full Stack",
+      "fecha": "Octubre 2022 - Octubre 2023"
+    },
+    {
+      "centro": "IES La Rosaleda, Málaga",
+      "titulo": "Educación Secundaria Obligatoria (E.S.O.)",
+      "fecha": "Junio 2010"
+    }
+  ],
+  "experiencia": [
+    {
+      "proyecto": "Comer-IA",
+      "descripcion": "App con Next.js que genera recetas usando la API de OpenAI. Trabajé en integración de IA, despliegue y diseño responsive.",
+      "tecnologias": ["Next.js", "OpenAI API", "CSS"],
+      "link": "https://www.comer-ia.com/"
+    },
+    {
+      "proyecto": "Wahaha",
+      "descripcion": "Red social de chistes donde los usuarios pueden subir, puntuar y guardar favoritos. Proyecto full stack con énfasis en UX y diseño.",
+      "tecnologias": ["React", "Node.js", "MongoDB", "JavaScript", "CSS"],
+      "link": null
+    },
+    {
+      "proyecto": "SimonaZappoli",
+      "descripcion": "Sitio web estático para una profesional del bienestar. Diseñado según necesidades reales del cliente, con enfoque en usabilidad.",
+      "tecnologias": ["React", "HTML", "CSS", "JavaScript"],
+      "link": "https://simona-zappoli.pages.dev/"
+    },
+    {
+      "proyecto": "Adivina el Número",
+      "descripcion": "Juego web simple para practicar lógica y control de flujo en JavaScript. Incluye niveles de dificultad.",
+      "tecnologias": ["HTML", "CSS", "JavaScript"],
+      "link": "https://gessthenumber.pages.dev/"
+    },
+    {
+      "proyecto": "Rick and Morty API",
+      "descripcion": "App que consume la API de Rick and Morty con scroll infinito y búsqueda en tiempo real. Enfocada en el diseño y consumo de API.",
+      "tecnologias": ["React", "JavaScript", "CSS", "Rick and Morty API"],
+      "link": "https://rick-and-morty-characters.pages.dev/"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `src/data/datos.json` as single source of truth
- refactor BodyJson to read from shared data
- generate markdown and env tabs from shared data
- localize VSCode simulator tabs in Spanish

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c24c2d5234832398229ae5e63f78be