### PR TITLE
Add skills tab and overview sections

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import Footer from "./components/Footer/Footer";
 import Start from "./components/Start/Start";
 import About from "./components/About/About";
 import Projects from "./components/Projects/Projects";
+import SkillsOverview from "./components/SkillsOverview/SkillsOverview";
 
 export default function App() {
   return (
@@ -18,6 +19,7 @@ export default function App() {
             <>
               <Start />
               <About />
+              <SkillsOverview />
               <Projects />
             </>
           }

--- a/src/components/BodySkills/BodySkills.css
+++ b/src/components/BodySkills/BodySkills.css
@@ -1,0 +1,112 @@
+.bodySkills {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  color: #ffffff;
+  background: transparent;
+}
+
+.bodySkills__title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.skillsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.skillCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: #141414;
+  border: 1px solid #262626;
+  border-radius: 16px;
+  padding: 1.2rem 1.4rem;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.skillCard:hover,
+.skillCard:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.skillCard__icon {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.skillCard__icon .imgSkill {
+  width: 68px;
+  height: auto;
+}
+
+.skillCard__name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.projectChipList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.projectChipItem {
+  margin: 0;
+}
+
+.projectChip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid #3a3a3a;
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.projectChip:hover,
+.projectChip:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #5f5f5f;
+}
+
+@media (max-width: 768px) {
+  .bodySkills {
+    padding: 1.25rem;
+  }
+
+  .skillCard__icon .imgSkill {
+    width: 60px;
+  }
+}
+
+@media (max-width: 480px) {
+  .bodySkills {
+    padding: 1rem;
+  }
+
+  .skillsGrid {
+    gap: 12px;
+  }
+
+  .skillCard {
+    padding: 1rem 1.2rem;
+  }
+}

--- a/src/components/BodySkills/BodySkills.jsx
+++ b/src/components/BodySkills/BodySkills.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import "./BodySkills.css";
+import SkillsImage from "../SkillsImage/SkillsImage";
+import { SKILLS } from "../../data/skills";
+
+const BodySkills = () => {
+  return (
+    <section className="bodySkills" aria-labelledby="body-skills-title">
+      <h2 id="body-skills-title" className="bodySkills__title">
+        Skills
+      </h2>
+      <div className="skillsGrid">
+        {SKILLS.map(({ id, name, projects }) => (
+          <article key={id} className="skillCard">
+            <div className="skillCard__icon" aria-hidden="true">
+              <SkillsImage skill={id} />
+            </div>
+            <div className="skillCard__content">
+              <h3 className="skillCard__name">{name}</h3>
+              <ul
+                className="projectChipList"
+                aria-label={`Proyectos donde utilizo ${name}`}
+              >
+                {projects.map(({ href, label }) => (
+                  <li key={href} className="projectChipItem">
+                    <a className="projectChip" href={href}>
+                      {label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default BodySkills;

--- a/src/components/SkillsOverview/SkillsOverview.css
+++ b/src/components/SkillsOverview/SkillsOverview.css
@@ -1,0 +1,109 @@
+.skillsOverview {
+  width: 100%;
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+  color: #ffffff;
+  box-sizing: border-box;
+}
+
+.skillsOverview__title {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.skillsOverview__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.skillsOverview__card {
+  background: #141414;
+  border: 1px solid #262626;
+  border-radius: 14px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.skillsOverview__card:hover,
+.skillsOverview__card:focus-within {
+  transform: translateY(-3px);
+  border-color: #3a3a3a;
+}
+
+.skillsOverview__icon .imgSkill {
+  width: 60px;
+}
+
+.skillsOverview__name {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.skillsOverview__projects {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.skillsOverview__chipItem {
+  margin: 0;
+}
+
+.skillsOverview__chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid #3a3a3a;
+  background: rgba(255, 255, 255, 0.04);
+  color: #ffffff;
+  font-size: 0.75rem;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.skillsOverview__chip:hover,
+.skillsOverview__chip:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #5f5f5f;
+}
+
+@media (max-width: 768px) {
+  .skillsOverview {
+    padding: 2.5rem 1.25rem;
+  }
+
+  .skillsOverview__title {
+    font-size: 1.75rem;
+  }
+
+  .skillsOverview__icon .imgSkill {
+    width: 50px;
+  }
+}
+
+@media (max-width: 480px) {
+  .skillsOverview__grid {
+    gap: 0.75rem;
+  }
+
+  .skillsOverview {
+    padding: 2.25rem 1rem;
+  }
+
+  .skillsOverview__card {
+    padding: 1rem;
+  }
+}

--- a/src/components/SkillsOverview/SkillsOverview.jsx
+++ b/src/components/SkillsOverview/SkillsOverview.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import "./SkillsOverview.css";
+import SkillsImage from "../SkillsImage/SkillsImage";
+import { SKILLS } from "../../data/skills";
+
+const SkillsOverview = () => {
+  return (
+    <section className="skillsOverview" aria-labelledby="skills-overview-title">
+      <h2 id="skills-overview-title" className="skillsOverview__title">
+        Skills
+      </h2>
+      <div className="skillsOverview__grid">
+        {SKILLS.map(({ id, name, projects }) => (
+          <article key={id} className="skillsOverview__card">
+            <div className="skillsOverview__icon" aria-hidden="true">
+              <SkillsImage skill={id} />
+            </div>
+            <h3 className="skillsOverview__name">{name}</h3>
+            <ul
+              className="skillsOverview__projects"
+              aria-label={`Proyectos destacados con ${name}`}
+            >
+              {projects.map(({ href, label }) => (
+                <li key={href} className="skillsOverview__chipItem">
+                  <a className="skillsOverview__chip" href={href}>
+                    {label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default SkillsOverview;

--- a/src/components/Start/Start.js
+++ b/src/components/Start/Start.js
@@ -2,6 +2,7 @@ import React from 'react';
 import "./Start.css"
 import Greeting from "../Greeting/Greeting";
 import Skills from '../Skills/Skills';
+import VSC from "../VSC/VSC";
 
 
 export default function Start() {
@@ -9,6 +10,7 @@ export default function Start() {
     <div>
         <Greeting />
         <Skills />
+        <VSC />
     </div>
   )
 }

--- a/src/components/VSC/VSC.css
+++ b/src/components/VSC/VSC.css
@@ -1,0 +1,224 @@
+.vsc {
+  background: #0f0f0f;
+  border: 1px solid #1f1f1f;
+  border-radius: 18px;
+  overflow: hidden;
+  color: #ffffff;
+}
+
+.vsc__header {
+  display: none;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #1f1f1f;
+}
+
+.vsc__toggle {
+  appearance: none;
+  background: #1c1c1c;
+  border: 1px solid #2f2f2f;
+  border-radius: 8px;
+  color: #ffffff;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}
+
+.vsc__layout {
+  display: flex;
+  min-height: 460px;
+}
+
+.vsc__sidebar {
+  width: 240px;
+  background: #111111;
+  border-right: 1px solid #1f1f1f;
+  padding: 1rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.vsc__sidebarTitle {
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  color: #8a8a8a;
+  margin: 0;
+}
+
+.vsc__fileList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.vsc__fileButton {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: transparent;
+  color: #cfcfcf;
+  border: none;
+  border-radius: 8px;
+  padding: 0.45rem 0.55rem;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.vsc__fileButton:hover,
+.vsc__fileButton:focus-visible {
+  background: #1d1d1d;
+  color: #ffffff;
+}
+
+.vsc__fileButton.is-active {
+  background: #242424;
+  color: #ffffff;
+}
+
+.vsc__fileIcon {
+  width: 1.5rem;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.vsc__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #181818;
+}
+
+.vsc__tabs {
+  display: flex;
+  align-items: stretch;
+  background: #141414;
+  border-bottom: 1px solid #1f1f1f;
+  overflow-x: auto;
+}
+
+.vsc__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.9rem;
+  border-right: 1px solid #1f1f1f;
+  cursor: pointer;
+  color: #b5b5b5;
+  font-size: 0.9rem;
+  user-select: none;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.vsc__tab.is-active {
+  background: #1f1f1f;
+  color: #ffffff;
+}
+
+.vsc__tabClose {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.vsc__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
+.vscBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: #f5f5f5;
+}
+
+.vscBody h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.vscBody p,
+.vscBody pre,
+.vscBody dl {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.vscBody pre {
+  background: #101010;
+  border-radius: 12px;
+  padding: 1rem;
+  color: #9cdcfe;
+  font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
+    monospace;
+  white-space: pre-wrap;
+}
+
+.vscBody dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.5rem 1rem;
+}
+
+.vscBody dt {
+  color: #9fd86b;
+}
+
+.vscBody dd {
+  margin: 0;
+}
+
+.vscBody a {
+  color: #9fd86b;
+}
+
+@media (max-width: 960px) {
+  .vsc__layout {
+    flex-direction: column;
+  }
+
+  .vsc__header {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .vsc__sidebar {
+    position: absolute;
+    z-index: 2;
+    height: 100%;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+  }
+
+  .vsc__sidebar.is-open {
+    transform: translateX(0);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+  }
+
+  .vsc__main {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .vsc__content {
+    padding: 1.1rem;
+  }
+
+  .vscBody h2 {
+    font-size: 1.2rem;
+  }
+}

--- a/src/components/VSC/VSC.jsx
+++ b/src/components/VSC/VSC.jsx
@@ -1,0 +1,186 @@
+import React, { useMemo, useState } from "react";
+import "./VSC.css";
+import BodySkills from "../BodySkills/BodySkills";
+
+const iconMd = "📝";
+const iconJson = "{ }";
+const iconEnv = "🔐";
+
+const fileList = [
+  { name: "SobreMi.md", icon: iconMd },
+  { name: "datos.json", icon: iconJson },
+  { name: "contacto.env", icon: iconEnv },
+  { name: "Skills.md", icon: iconMd },
+];
+
+const defaultContent = {
+  "SobreMi.md": (
+    <article className="vscBody vscBody--md">
+      <h2>Sobre mí</h2>
+      <p>
+        ¡Hola! Soy Manuel, desarrollador web con foco en construir interfaces
+        limpias y experiencias accesibles. Me gusta trabajar con React y crear
+        herramientas que resuelvan problemas reales.
+      </p>
+      <p>
+        Disfruto colaborar en equipo, compartir conocimiento y mantener una
+        comunicación clara con las personas involucradas en cada proyecto.
+      </p>
+    </article>
+  ),
+  "datos.json": (
+    <article className="vscBody vscBody--json">
+      <pre>
+        {`{
+  "role": "Desarrollador Web",
+  "experience": "+3 años",
+  "location": "Madrid, España",
+  "interests": ["UI", "APIs", "Productos digitales"]
+}`}
+      </pre>
+    </article>
+  ),
+  "contacto.env": (
+    <article className="vscBody vscBody--env">
+      <dl>
+        <div>
+          <dt>Email</dt>
+          <dd><a href="mailto:hola@wahandri.dev">hola@wahandri.dev</a></dd>
+        </div>
+        <div>
+          <dt>LinkedIn</dt>
+          <dd>
+            <a href="https://www.linkedin.com/in/wahandri/">linkedin.com/in/wahandri</a>
+          </dd>
+        </div>
+        <div>
+          <dt>GitHub</dt>
+          <dd>
+            <a href="https://github.com/Wahandri">github.com/Wahandri</a>
+          </dd>
+        </div>
+      </dl>
+    </article>
+  ),
+};
+
+const VSC = () => {
+  const defaultFileName = useMemo(() => fileList[0].name, []);
+  const [openFiles, setOpenFiles] = useState([defaultFileName]);
+  const [activeFile, setActiveFile] = useState(defaultFileName);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  const handleFileClick = (fileName) => {
+    setOpenFiles((prev) => {
+      if (prev.includes(fileName)) {
+        return prev;
+      }
+      return [...prev, fileName];
+    });
+    setActiveFile(fileName);
+    setIsSidebarOpen(false);
+  };
+
+  const closeFile = (fileName) => {
+    setOpenFiles((prev) => {
+      if (!prev.includes(fileName)) {
+        return prev;
+      }
+      let updated = prev.filter((name) => name !== fileName);
+      if (!updated.length) {
+        updated = [defaultFileName];
+      }
+      setActiveFile((current) => {
+        if (current === fileName) {
+          return updated[updated.length - 1];
+        }
+        return current;
+      });
+      return updated;
+    });
+  };
+
+  const renderContent = () => {
+    switch (activeFile) {
+      case "Skills.md":
+        return <BodySkills />;
+      default:
+        return defaultContent[activeFile] || null;
+    }
+  };
+
+  return (
+    <div className="vsc">
+      <div className="vsc__header">
+        <button
+          type="button"
+          className="vsc__toggle"
+          onClick={() => setIsSidebarOpen((prev) => !prev)}
+        >
+          Explorador
+        </button>
+      </div>
+      <div className="vsc__layout">
+        <aside className={`vsc__sidebar ${isSidebarOpen ? "is-open" : ""}`}>
+          <h3 className="vsc__sidebarTitle">PORTFOLIO</h3>
+          <ul className="vsc__fileList">
+            {fileList.map((file) => (
+              <li key={file.name}>
+                <button
+                  type="button"
+                  className={`vsc__fileButton ${
+                    activeFile === file.name ? "is-active" : ""
+                  }`}
+                  onClick={() => handleFileClick(file.name)}
+                >
+                  <span className="vsc__fileIcon" aria-hidden="true">
+                    {file.icon}
+                  </span>
+                  <span>{file.name}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+        <div className="vsc__main">
+          <div className="vsc__tabs" role="tablist" aria-label="Archivos abiertos">
+            {openFiles.map((fileName) => (
+              <div
+                key={fileName}
+                className={`vsc__tab ${fileName === activeFile ? "is-active" : ""}`}
+                role="tab"
+                aria-selected={fileName === activeFile}
+                tabIndex={fileName === activeFile ? 0 : -1}
+                onClick={() => setActiveFile(fileName)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    setActiveFile(fileName);
+                  }
+                }}
+              >
+                <span>{fileName}</span>
+                <button
+                  type="button"
+                  className="vsc__tabClose"
+                  aria-label={`Cerrar ${fileName}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    closeFile(fileName);
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+          <div className="vsc__content" role="tabpanel">
+            {renderContent()}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VSC;

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -1,0 +1,64 @@
+export const SKILLS = [
+  {
+    id: "html",
+    name: "HTML5",
+    projects: [
+      { label: "Comer-IA", href: "#comer-ia" },
+      { label: "Adivina el Numero", href: "#adivina-el-numero" },
+    ],
+  },
+  {
+    id: "css",
+    name: "CSS3",
+    projects: [
+      { label: "Comer-IA", href: "#comer-ia" },
+      { label: "SimonaZappoli", href: "#simonazappoli" },
+    ],
+  },
+  {
+    id: "js",
+    name: "JavaScript",
+    projects: [
+      { label: "Adivina el Numero", href: "#adivina-el-numero" },
+      { label: "Rick and Morty API", href: "#rick-and-morty-api" },
+    ],
+  },
+  {
+    id: "react",
+    name: "React",
+    projects: [
+      { label: "Comer-IA", href: "#comer-ia" },
+      { label: "Digimon-Online", href: "#digimon-online" },
+    ],
+  },
+  {
+    id: "nextjs",
+    name: "Next.js",
+    projects: [{ label: "Comer-IA", href: "#comer-ia" }],
+  },
+  {
+    id: "node",
+    name: "Node.js",
+    projects: [{ label: "Wahaha", href: "#wahaha" }],
+  },
+  {
+    id: "git",
+    name: "Git",
+    projects: [
+      { label: "Wahaha", href: "#wahaha" },
+      { label: "SimonaZappoli", href: "#simonazappoli" },
+    ],
+  },
+  {
+    id: "mysql",
+    name: "MySQL",
+    projects: [{ label: "SimonaZappoli", href: "#simonazappoli" }],
+  },
+  {
+    id: "mongo",
+    name: "MongoDB",
+    projects: [{ label: "Wahaha", href: "#wahaha" }],
+  },
+];
+
+export default SKILLS;


### PR DESCRIPTION
## Summary
- add shared SKILLS data and render a new BodySkills grid for the VS Code-style view
- introduce a SkillsOverview section with responsive cards and project chips
- extend the Start layout with the refreshed VSC component and surface the overview on the home route

## Testing
- `npm test -- --watch=false` *(fails: react-scripts missing because dependencies could not be installed in the environment)*
- `npm install` *(fails: npm registry returned 403 for react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1fa67c0c8323942db142aea5c4f9